### PR TITLE
fix: user toknes incorrect order

### DIFF
--- a/packages/indexer/src/api/endpoints/tokens/get-user-tokens/v10.ts
+++ b/packages/indexer/src/api/endpoints/tokens/get-user-tokens/v10.ts
@@ -882,7 +882,7 @@ export const getUserTokensV10Options: RouteOptions = {
               1
           ) ELSE t.floor_sell_id END
           ${userCollectionsSorting}
-          ${sortFullResultsSet ? nftBalanceSorting : ""}
+          ${nftBalanceSorting}
           ${limitFullResultsSet ? limit : ""}
       `;
 

--- a/packages/indexer/src/api/endpoints/tokens/get-user-tokens/v9.ts
+++ b/packages/indexer/src/api/endpoints/tokens/get-user-tokens/v9.ts
@@ -815,7 +815,7 @@ export const getUserTokensV9Options: RouteOptions = {
               1
           ) ELSE t.floor_sell_id END
           ${userCollectionsSorting}
-          ${sortFullResultsSet ? nftBalanceSorting : ""}
+          ${nftBalanceSorting}
           ${limitFullResultsSet ? limit : ""}
       `;
 


### PR DESCRIPTION
API `/users/{user}/tokens/v10` and `/users/{user}/tokens/v9` return tokens in reversed order. Because of that, calling those APIs again with `continuation` param will also return results with duplicated tokens.

E.g.
1st time call: return token: 1,2, ... 20
2nd time call: return tokens: 2,3,...21
...
<!-- ## Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules. -->